### PR TITLE
Implement android fixes

### DIFF
--- a/VentFrameworkContinued.csproj
+++ b/VentFrameworkContinued.csproj
@@ -10,32 +10,21 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/music-discussion/VentFramework-Continued/</RepositoryUrl>
-        <AmongUs>D:\Games\AmongUs\steam\Lotus</AmongUs>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
         <GitVersion>false</GitVersion>
         <DocumentationFile>bin\Debug\VentFrameworkContinued.xml</DocumentationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
-        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2025.9.9</GameVersion>
-        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2025.9.9</GameVersion>
-
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(AmongUs)' == ''">
+        <AmongUs>D:\Games\AmongUs\steam\Lotus</AmongUs>
     </PropertyGroup>
 
     <ItemGroup>
         <EmbeddedResource Include=".\assets\**\*" />
     </ItemGroup>
-
-    <PropertyGroup Condition=" '$(Platform)' == 'Android' ">
-        <DefineConstants>TRACE;ANDROID</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
-        <DefineConstants>TRACE;PC</DefineConstants>
-    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Costura.Fody" Version="5.7.0">
@@ -49,8 +38,7 @@
         </PackageReference>
         <PackageReference Include="Pastel" Version="4.1.0" />
         <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.19" />
-        <PackageReference Condition="$(Platform)=='Android'" Include="AmongUs.GameLibs.Android" Version="2025.9.9" PrivateAssets="all" />
-        <PackageReference Condition="$(Platform)=='AnyCPU'" Include="AmongUs.GameLibs.Steam" Version="2025.10.14" PrivateAssets="all" />
+        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2025.10.14" PrivateAssets="all" />
         <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.0.1" PrivateAssets="all" />
         <PackageReference Include="YamlDotNet" Version="12.3.1" PrivateAssets="all" />

--- a/VentFrameworkContinued.sln
+++ b/VentFrameworkContinued.sln
@@ -9,19 +9,12 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Debug|Android = Debug|Android
-		Release|Android = Release|Android
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D272FE21-4757-4346-9E69-578EAEED3E37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D272FE21-4757-4346-9E69-578EAEED3E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D272FE21-4757-4346-9E69-578EAEED3E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D272FE21-4757-4346-9E69-578EAEED3E37}.Release|Any CPU.Build.0 = Release|Any CPU
-
-		{D272FE21-4757-4346-9E69-578EAEED3E37}.Debug|Android.ActiveCfg = Debug|Android
-		{D272FE21-4757-4346-9E69-578EAEED3E37}.Debug|Android.Build.0 = Debug|Android
-		{D272FE21-4757-4346-9E69-578EAEED3E37}.Release|Android.ActiveCfg = Release|Android
-		{D272FE21-4757-4346-9E69-578EAEED3E37}.Release|Android.Build.0 = Release|Android
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Vents.cs
+++ b/Vents.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using BepInEx;
+using UnityEngine;
 using VentLib.Commands;
 using VentLib.Localization;
 using VentLib.Logging;
@@ -26,6 +27,7 @@ namespace VentLib;
 [BepInProcess("Among Us.exe")]
 public partial class Vents : BasePlugin
 {
+    public static string BasePath => OperatingSystem.IsAndroid() ? Application.persistentDataPath : Paths.GameRootPath;
     public static readonly uint[] BuiltinRPCs = Enum.GetValues<VentCall>().Select(rpc => (uint)rpc).ToArray();
     internal static VersionControl VersionControl { get; } = new();
     public static CommandRunner CommandRunner = new();

--- a/src/Localization/LocalizerSettings.cs
+++ b/src/Localization/LocalizerSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using BepInEx;
@@ -20,20 +21,12 @@ public class LocalizerSettings
         OptionManager manager = new(Assembly.GetExecutingAssembly(), "locale.config", OptionManagerFlags.IgnorePreset);
         Option languageFolderOption = new OptionBuilder().Name("Language Folder")
             .Description("Folder where translations are stored")
-            #if ANDROID
             .Value("VentLanguages")
-            #else
-            .Value("Languages")
-            #endif
             .IOSettings(settings => settings.UnknownValueAction = ADEAnswer.Allow)
             .BuildAndRegister(manager);
 
         LanguageFolder = languageFolderOption.GetValue<string>();
-        #if ANDROID
-        LanguageDirectory = new DirectoryInfo(Path.Combine(Application.persistentDataPath, LanguageFolder));
-        #else
-        LanguageDirectory = new DirectoryInfo(Path.Combine(Paths.GameRootPath, LanguageFolder));
-        #endif
+        LanguageDirectory = new DirectoryInfo(Path.Combine(Vents.BasePath, LanguageFolder));
         if (!LanguageDirectory.Exists) LanguageDirectory.Create();
     }
 

--- a/src/Logging/Accumulators/TypePaddingAccumulator.cs
+++ b/src/Logging/Accumulators/TypePaddingAccumulator.cs
@@ -47,7 +47,7 @@ public abstract class TypePaddingAccumulator: ILogAccumulator
             
             if (remaining < 0)
             {
-                reverseList.AddRange(splitQualifier[..(i+1)].Reverse().Select(q => q.Length > 0 ? q[0].ToString() : ""));
+                reverseList.AddRange(splitQualifier[..(i+1)].AsEnumerable().Reverse().Select(q => q.Length > 0 ? q[0].ToString() : ""));
                 break;
             }
             

--- a/src/Logging/Appenders/FlushingMemoryAppender.cs
+++ b/src/Logging/Appenders/FlushingMemoryAppender.cs
@@ -11,12 +11,8 @@ namespace VentLib.Logging.Appenders;
 
 public class FlushingMemoryAppender: InMemoryAppender
 {
-    #if ANDROID
     private static StandardLogger? _log;
-    private static StandardLogger log => _log ??= LoggerFactory.GetLogger<StandardLogger>(typeof(FlushingMemoryAppender));
-    #else
-    private static readonly StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(FlushingMemoryAppender));
-    #endif
+    private static StandardLogger LOG => _log ??= LoggerFactory.GetLogger<StandardLogger>(typeof(FlushingMemoryAppender));
     
     private DirectoryInfo TargetDirectory { get; }
     public string FileNamePattern;
@@ -42,11 +38,8 @@ public class FlushingMemoryAppender: InMemoryAppender
     public FlushingMemoryAppender(string directoryPath, string filenamePattern, LogLevel? minLevel = null)
     {
         FileNamePattern = filenamePattern;
-        #if ANDROID
-        TargetDirectory = new DirectoryInfo(Path.Combine(Application.persistentDataPath, directoryPath));
-        #else
-        TargetDirectory = new DirectoryInfo(directoryPath);
-        #endif
+        TargetDirectory = new DirectoryInfo(Path.Combine(Vents.BasePath, directoryPath));
+
         if (!TargetDirectory.Exists) TargetDirectory.Create();
         MinLevel = minLevel ?? LogLevel.Info;
         flushingThread = new Thread(FlushMemory) { IsBackground = true };
@@ -81,7 +74,7 @@ public class FlushingMemoryAppender: InMemoryAppender
             }
             catch (Exception exception)
             {
-                log.Exception(exception);
+                LOG.Exception(exception);
             }
             finally
             {

--- a/src/Logging/Default/DefaultLogConfig.cs
+++ b/src/Logging/Default/DefaultLogConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using VentLib.Logging.Appenders;
 using VentLib.Options;
@@ -66,11 +67,7 @@ public class DefaultLogConfig
                 .SubOption(sub => sub
                     .Name("Log Directory")
                     .Description("Directory for storing log files.")
-                    #if ANDROID
                     .Value("vf_logs")
-                    #else
-                    .Value("logs")
-                    #endif
                     .IOSettings(settings => settings.UnknownValueAction = ADEAnswer.Allow)
                     .Build())
                 .SubOption(sub => sub

--- a/src/Logging/LogDirectory.cs
+++ b/src/Logging/LogDirectory.cs
@@ -16,23 +16,15 @@ public class LogDirectory
 {
     public static string Directory
     {
-        get => _path;
-        #if ANDROID
-        set => _directory = ValidateDirectory(new DirectoryInfo(Path.Combine(Application.persistentDataPath, _path = value)), true);
-        #else 
-        set => _directory = ValidateDirectory(new DirectoryInfo(Path.Combine(Paths.GameRootPath, _path = value)), true);
-        #endif
+        get;
+        set => _directory = ValidateDirectory(new DirectoryInfo(Path.Combine(Vents.BasePath, field = value)), true);
     }
-    private static string _path = "";
+
     private static DirectoryInfo _directory;
 
     static LogDirectory()
     {
-        #if ANDROID
         Directory = "vf_logs";
-        #else
-        Directory = "logs";
-#endif
     }
 
     public static IEnumerable<FileInfo> GetLogs(string regex, DirectoryInfo? dir = null)

--- a/src/Logging/LogDirectory.cs
+++ b/src/Logging/LogDirectory.cs
@@ -17,14 +17,18 @@ public class LogDirectory
     public static string Directory
     {
         get;
-        set => _directory = ValidateDirectory(new DirectoryInfo(Path.Combine(Vents.BasePath, field = value)), true);
+        set
+        {
+            field = value;
+            _directory = ValidateDirectory(new DirectoryInfo(value), true);
+        }
     }
 
     private static DirectoryInfo _directory;
 
     static LogDirectory()
     {
-        Directory = "vf_logs";
+        Directory = Path.Combine(Vents.BasePath, "vf_logs");
     }
 
     public static IEnumerable<FileInfo> GetLogs(string regex, DirectoryInfo? dir = null)

--- a/src/Networking/Helpers/RpcHookHelper.cs
+++ b/src/Networking/Helpers/RpcHookHelper.cs
@@ -17,11 +17,7 @@ internal class RpcHookHelper
     private static readonly OpCode[] Ldc = { OpCodes.Ldc_I4_0, OpCodes.Ldc_I4_1, OpCodes.Ldc_I4_2, OpCodes.Ldc_I4_3, OpCodes.Ldc_I4_4, OpCodes.Ldc_I4_5, OpCodes.Ldc_I4_6, OpCodes.Ldc_I4_7, OpCodes.Ldc_I4_8 };
     private static readonly OpCode[] Ldarg = { OpCodes.Ldarg_0, OpCodes.Ldarg_1, OpCodes.Ldarg_2, OpCodes.Ldarg_3 };
 
-    #if ANDROID
-    internal static Detour Generate(ModRPC modRPC)
-    #else
     internal static Hook Generate(ModRPC modRPC)
-    #endif
     {
         MethodInfo executingMethod = modRPC.TargetMethod;
         Type[] parameters = executingMethod.GetParameters().Select(p => p.ParameterType).ToArray();
@@ -67,11 +63,7 @@ internal class RpcHookHelper
         ilg.Emit(OpCodes.Ret);
 
         _senders.Add(new DetouredSender(modRPC));
-        #if ANDROID
-        return new Detour(executingMethod, m);
-        #else
         return new Hook(executingMethod, m);
-        #endif
     }
 
     private static DetouredSender GetSender(int index) => _senders[index];

--- a/src/Networking/RPC/ModRPC.cs
+++ b/src/Networking/RPC/ModRPC.cs
@@ -2,8 +2,8 @@ extern alias JetbrainsAnnotations;
 using System;
 using System.Reflection;
 using HarmonyLib;
-using JetbrainsAnnotations::JetBrains.Annotations;
 using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
 using VentLib.Logging;
 using VentLib.Networking.Helpers;
 using VentLib.Networking.Interfaces;
@@ -27,6 +27,7 @@ public class ModRPC
     internal DetouredSender Sender = null!;
     private readonly MethodBase trampoline;
     private readonly Func<object?> instanceSupplier;
+    private readonly Hook _hook;
 
     internal ModRPC(ModRPCAttribute attribute, MethodInfo targetMethod)
     {
@@ -42,12 +43,8 @@ public class ModRPC
             throw new ArgumentException($"Unable to Register: {targetMethod.Name}. Reason: VentLib does not current allow for methods without declaring types");
 
         Assembly = declaringType.Assembly;
-        #if ANDROID
-        Detour hook = RpcHookHelper.Generate(this);
-        #else
-        Hook hook = RpcHookHelper.Generate(this);
-        #endif 
-        trampoline = hook.GenerateTrampoline();
+        trampoline = new DynamicMethodDefinition(targetMethod).Generate();
+        _hook = RpcHookHelper.Generate(this);
 
         instanceSupplier = () =>
         {

--- a/src/Options/Option.cs
+++ b/src/Options/Option.cs
@@ -19,12 +19,8 @@ namespace VentLib.Options;
 
 public class Option: IRpcSendable<Option>
 {
-    #if ANDROID
     private static StandardLogger? _log;
     private static StandardLogger Log => _log ??= LoggerFactory.GetLogger<StandardLogger>(typeof(Option));
-    #else
-    private static StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(Option));
-    #endif
     
     private static ModRPC _modRPC = Vents.FindRPC((uint)VentCall.SyncSingleOption)!;
     // ReSharper disable once InconsistentNaming

--- a/src/Utilities/Async.cs
+++ b/src/Utilities/Async.cs
@@ -12,12 +12,8 @@ namespace VentLib.Utilities;
 
 public class Async
 {
-    #if ANDROID
     private static StandardLogger? _log;
     private static StandardLogger log => _log ??= LoggerFactory.GetLogger<StandardLogger>(typeof(Async));
-    #else
-    private static StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(Async));
-    #endif
     internal static AUCWrapper AUCWrapper { get; } = new();
 
     /// <summary>

--- a/src/Utilities/Extensions/EnumerableExtensions.cs
+++ b/src/Utilities/Extensions/EnumerableExtensions.cs
@@ -12,12 +12,8 @@ namespace VentLib.Utilities.Extensions;
 
 public static class EnumerableExtensions
 {
-    #if ANDROID
     private static StandardLogger? _log;
     private static StandardLogger log => _log ??= LoggerFactory.GetLogger<StandardLogger>(typeof(EnumerableExtensions));
-    #else
-    private static StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(EnumerableExtensions));
-    #endif
     
     /// <summary>
     /// Maps a sequence into a new type, keeping all non-null values.

--- a/src/Version/Updater/ModUpdater.cs
+++ b/src/Version/Updater/ModUpdater.cs
@@ -18,11 +18,7 @@ public class ModUpdater
 {
     private static StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(ModUpdater));
     private static Regex _regex = new("/github\\.com\\/(.*)\\/(.*)\\.git");
-    #if ANDROID
-    private static DirectoryInfo _backupsDirectory = new(Path.Combine(Application.persistentDataPath, "VentBackups"));
-    #else
-    private static DirectoryInfo _backupsDirectory = new(Path.Combine(Paths.GameRootPath, "Backups"));
-    #endif
+    private static DirectoryInfo _backupsDirectory = new(Path.Combine(Vents.BasePath, "VentBackups"));
     
     private GitVersion currentVersion;
     private string repositoryOwner;


### PR DESCRIPTION
This PR is fairly simple.

First of all, we remove all compile time Android changes and make them runtime. This lets us make a single cross-platform DLL.

Next, I don't know why all the folder names and such were different for android, using prefixes like vf_ or vent. I just made it so all of them are using the "prefixed" version so it is identifiable as VentFramework folders. Additionally, I had to adjust the RPC Hooks a bit. Since Starlight uses reorg MonoMod, we have to use DynamicMethodDefinition to generate a trampoline. Theres no issue with this on PC since we use the same approach in Reactor for Starlight (which works on PC too) without problems. Finally, I changed all instances of the logger with a backing _log field to just do that instead of having a different definition on PC.

Seems to work fine, loaded into Starlight without any errors. Testing will be required once Project Lotus itself is running.